### PR TITLE
Добавлена документация по RMS-54799+RMS-54797, RMS-54771 и отредактирована документация по RMS-53625.

### DIFF
--- a/_posts/2022-08-16-ride.md
+++ b/_posts/2022-08-16-ride.md
@@ -21,3 +21,5 @@ tags: v8preview2 v8
 * [`ChangeRideExternalId`](https://iiko.github.io/front.api.sdk/v8/html/M_Resto_Front_Api_IOperationService_ChangeRideExternalId.htm) позволяет указать идентификатор поездки во внешней системе ([`Ride.ExternalId`](https://iiko.github.io/front.api.sdk/v8/html/P_Resto_Front_Api_Data_Brd_Ride_ExternalId.htm)).
 * [`ChangeRideExternalCouier`](https://iiko.github.io/front.api.sdk/v8/html/M_Resto_Front_Api_IOperationService_ChangeRideExternalCouier.htm) меняет курьера внешней курьерской службы в связанной с доставкой поездке.  
 Данный метод заменил `ChangeDeliveryExternalCourier`, который раньше использовался для изменения внешнего курьера в самой доставке.
+
+Для связи доставочного заказа с поездкой добавлен новый метод [`TryGetRideByDeliveryOrderId`](https://iiko.github.io/front.api.sdk/v8/html/M_Resto_Front_Api_IOperationService_TryGetRideByDeliveryOrderId.htm), с помощью которого можно определить, какая поездка назначена для указанной доставки.

--- a/_posts/2025-05-13-FixedRestrictions.md
+++ b/_posts/2025-05-13-FixedRestrictions.md
@@ -1,0 +1,21 @@
+---
+title: Возможность запретить фронту изменять переданные из АПИ значения продолжительности и зоны доставки
+layout: default
+tags: v9preview1 v9
+---
+
+Начиная с V9Preview1 появилась возможность запретить фронту менять рассчитанные внешним ГРиКом и переданные из АПИ значения продолжительности и зоны доставки.
+
+В доставочный заказ [`IDeliveryOrder`](https://iiko.github.io/front.api.sdk/v9/html/T_Resto_Front_Api_Data_Orders_IDeliveryOrder.htm) добавлено новое поле [`FixedRestrictions`](https://iiko.github.io/front.api.sdk/v9/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_FixedRestrictions.htm), с помощью которого можно или разрешать фронту заменять значения продолжительности доставки [`Duration`](https://iiko.github.io/front.api.sdk/v9/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_Duration.htm)
+ и зоны [`Zone`](https://iiko.github.io/front.api.sdk/v9/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_Zone.htm)
+ на те, которые фронт получает из "своего" ГРиК, или, наоборот, не давать редактировать поля `Duration` и `Zone`, оставив в них полученные из АПИ данные.
+
+Для того, чтобы воспользоваться новым функционалом, нужно при создании доставки из АПИ в аргументах метода [`IEditSession.CreateDeliveryOrder`](https://iiko.github.io/front.api.sdk/v9/html/Overload_Resto_Front_Api_Editors_IEditSession_CreateDeliveryOrder.htm) передать не пустое значение продолжительности доставки в параметре `TimeSpan? duration` и в параметре `bool fixedRestrictions` передать `true`. Если при этом нужно передать и зафиксировать зону доставки, в параметре `string zone` также должно быть не пустое значение. При `IDeliveryOrder.FixedRestrictions = true` фронт не вызывает проверку ГРиК для данной доставки и, таким образом, оставляет значения продолжительности и зоны доставки неизменными.
+
+Значение `IDeliveryOrder.FixedRestrictions` автоматически сбрасывается фронтом на `false` только при смене режима обслуживания [`IOrderType`](https://iiko.github.io/front.api.sdk/v9/html/T_Resto_Front_Api_Data_Organization_IOrderType.htm).
+
+Изменить значение поля `IDeliveryOrder.FixedRestrictions` можно с помощью нового метода [`IEditSession.ChangeDeliveryFixedRestrictions`](https://iiko.github.io/front.api.sdk/v9/html/M_Resto_Front_Api_Editors_IEditSession_ChangeDeliveryFixedRestrictions.htm).
+
+При вызове методов редактирования доставочного заказа - изменения продолжительности доставки [`IEditSession.ChangeDeliveryDuration`](https://iiko.github.io/front.api.sdk/v9/html/M_Resto_Front_Api_Editors_IEditSession_ChangeDeliveryDuration.htm) или зоны [`IEditSession.ChangeDeliveryZone`](https://iiko.github.io/front.api.sdk/v9/html/M_Resto_Front_Api_Editors_IEditSession_ChangeDeliveryZone.htm) - фронт применит новые параметры, оставив IDeliveryOrder.FixedRestrictions без изменения.
+
+Если доставка с `IDeliveryOrder.FixedRestrictions = true` дошла до (старого) Call Center и ее изменили так, что вызвался ГРиК, флаг `IDeliveryOrder.FixedRestrictions` сбрасывается в `false`, а поля [`IDeliveryOrder.Duration`](https://iiko.github.io/front.api.sdk/v9/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_Duration.htm) и [`IDeliveryOrder.Zone`](https://iiko.github.io/front.api.sdk/v9/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_Zone.htm) будут отредактированы - в них запишутся значения, которые вернул ГРИК.

--- a/_posts/2025-05-16-MovedFromMovedToDeliveryId.md
+++ b/_posts/2025-05-16-MovedFromMovedToDeliveryId.md
@@ -1,0 +1,19 @@
+---
+title: Расширение информации о перенесенном доставочном заказе
+layout: default
+tags: v8preview5 v8
+---
+
+Начиная с V8Preview5 при переносе доставочного заказа на новую точку можно отследить, из какой группы и в какую был перенесен текущий доставочный заказ. А также теперь известен заказ на старой точке, который стал источником текущего.
+
+В дополнение к имеющимуся свойству [`MovedToDeliveryId`](https://iiko.github.io/front.api.sdk/v8/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_MovedToDeliveryId.htm) в доставочном заказе [`IDeliveryOrder`](https://iiko.github.io/front.api.sdk/v8/html/T_Resto_Front_Api_Data_Orders_IDeliveryOrder.htm) появились новые поля
+- [`MovedFromDeliveryId`](https://iiko.github.io/front.api.sdk/v8/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_MovedFromDeliveryId.htm) - прошлый идентификатор доставочного заказа до переноса на новую точку
+- [`MovedFromTerminalGroupId`](https://iiko.github.io/front.api.sdk/v8/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_MovedFromTerminalGroupId.htm) - идентификатор группы, которой принадлежала прошлая точка доставки
+- [`MovedToTerminalGroupId`](https://iiko.github.io/front.api.sdk/v8/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_MovedToTerminalGroupId.htm) - идентификатор группы, которой принадлежит текущая точка доставки
+
+По этим данным можно легко определить цепочку перемещения доставочного заказа при ее переносе на новую точку. 
+
+Для изменения значений полей, содержащих информацию о переносе доставочного заказа, взамен [`IEditSession.ChangeDeliveryMovedId`](https://iiko.github.io/front.api.sdk/v7/html/M_Resto_Front_Api_Editors_IEditSession_ChangeDeliveryMovedId.htm) добавлен новый метод
+[`IEditSession.ChangeDeliveryMoveIds`](https://iiko.github.io/front.api.sdk/v8/html/M_Resto_Front_Api_Editors_IEditSession_ChangeDeliveryMoveIds.htm), 
+позволяющий отредактировать любое из свойств `MovedFromDeliveryId`, `MovedFromTerminalGroupId`, `MovedToDeliveryId`, `MovedToTerminalGroupId`.
+Имеющийся ранее метод `IEditSession.ChangeDeliveryMovedId` удален.

--- a/_posts/2025-05-16-MovedFromMovedToDeliveryId.md
+++ b/_posts/2025-05-16-MovedFromMovedToDeliveryId.md
@@ -1,10 +1,10 @@
 ---
 title: Расширение информации о перенесенном доставочном заказе
 layout: default
-tags: v8preview5 v8
+tags: v8preview7 v8
 ---
 
-Начиная с V8Preview5 при переносе доставочного заказа на новую точку можно отследить, из какой группы и в какую был перенесен текущий доставочный заказ. А также теперь известен заказ на старой точке, который стал источником текущего.
+Начиная с V8Preview7 при переносе доставочного заказа на новую точку можно отследить, из какой группы и в какую был перенесен текущий доставочный заказ. А также теперь известен заказ на старой точке, который стал источником текущего.
 
 В дополнение к имеющимуся свойству [`MovedToDeliveryId`](https://iiko.github.io/front.api.sdk/v8/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_MovedToDeliveryId.htm) в доставочном заказе [`IDeliveryOrder`](https://iiko.github.io/front.api.sdk/v8/html/T_Resto_Front_Api_Data_Orders_IDeliveryOrder.htm) появились новые поля
 - [`MovedFromDeliveryId`](https://iiko.github.io/front.api.sdk/v8/html/P_Resto_Front_Api_Data_Orders_IDeliveryOrder_MovedFromDeliveryId.htm) - прошлый идентификатор доставочного заказа до переноса на новую точку


### PR DESCRIPTION
1. Добавлена статья в раздел "Что нового" для 
https://jira.iiko.ru/browse/RMS-54799
Добавить новые поля MovedFromTerminalGroupId/MovedToTerminalGroupId
и
https://jira.iiko.ru/browse/RMS-54797
Добавить новое поле MovedFromDeliveryId

2.  Добавлена статья в раздел "Что нового" для 
https://jira.iiko.ru/browse/RMS-54771
Не перезаписывать присланные значения длительности доставки (duration) и название зоны (zone) во Фронте

3. Добавлена информация в статью для
https://jira.iiko.ru/browse/RMS-53625
Сделать новый метод назначения курьера ВКС поездке вместо метода назначения курьера ВКС доставке.