### PR TITLE
Новость о доработках RegisterExternalOperation/CallExternalOperation (RMS-60539), добавление тэгов v10 и v10preview1 и исправление битой ссылки в статье

### DIFF
--- a/_posts/2025-06-19-einvoice-handlers-sampleplugin.md
+++ b/_posts/2025-06-19-einvoice-handlers-sampleplugin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: EInvoice API - обработчики в SamplePlugin для разработки
 layout: default
 tags: v9preview6 v9
@@ -18,5 +18,5 @@ tags: v9preview6 v9
 
 ### См. также
 
-* [Получение номера счета через API](https://iiko.github.io/front.api.doc/2025/04/25/get-invoice-number-from-api.html)
+* [Получение номера счета через API](https://iiko.github.io/front.api.doc/2025/06/20/get-invoice-number-from-api.html)
 * [`INotificationService`](https://iiko.github.io/front.api.sdk/v9/html/T_Resto_Front_Api_INotificationService.htm)

--- a/_posts/2026-05-06-external-operations-serializer-change.md
+++ b/_posts/2026-05-06-external-operations-serializer-change.md
@@ -1,0 +1,9 @@
+---
+title: Изменение сигнатур RegisterExternalOperation<TRequest, TResponse> и CallExternalOperation<TRequest, TResponse> в API V10
+layout: default
+tags: v10preview1 v10
+---
+
+Начиная с API V10Preview1 у `RegisterExternalOperation<TRequest, TResponse>` и `CallExternalOperation<TRequest, TResponse>` ([подробности]({{ site.baseurl }}{% post_url 2018-08-03-external operations%})) из сигнатуры удалены `SerializationBinder` и `ISurrogateSelector` в связи с заменой сериализатора на кроссплатформенный вариант.
+
+В методы теперь можно передать список `IReadOnlyCollection<Type> knownTypes` для поддержки полиморфной (де)сериализации. Пример использования можно посмотреть в [SamplePlugin](https://github.com/iiko/front.api.sdk/blob/master/sample/v10preview1/Resto.Front.Api.SamplePlugin/ExternalOperationsTester.cs). Также плагин может использовать альтернативные перегрузки `RegisterExternalOperation` и `CallExternalOperation` (с массивом байт в качестве параметров), самостоятельно реализовав логику (де)сериализации.

--- a/tag/v10.md
+++ b/tag/v10.md
@@ -1,0 +1,4 @@
+---
+layout: tagpage
+tag: v10
+---

--- a/tag/v10preview1.md
+++ b/tag/v10preview1.md
@@ -1,0 +1,4 @@
+---
+layout: tagpage
+tag: v10preview1
+---


### PR DESCRIPTION
Новость о доработках RegisterExternalOperation/CallExternalOperation (RMS-60539)
Добавление тэгов v10 (он уже указан в статье про выпуск V9 LTS, но самого тэга не было) и v10preview1
Исправление битой ссылки в старой статье